### PR TITLE
Fixing bug where the first Source was the only source used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mu-ts/configurations",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mu-ts/configurations",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mu-ts/configurations",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Convenience around configurations.",
   "main": "./lib/index",
   "types": "./lib/index",

--- a/src/core/Configurations.ts
+++ b/src/core/Configurations.ts
@@ -49,7 +49,8 @@ export class Configurations {
     this.logger.trace('get()', { name, someDefault });
 
     const value: any | undefined = await this.store._list.reduce(async (value: any | undefined, source: Source) => {
-      if (value) return value;
+      const resolvedValue = await value;
+      if (resolvedValue) return resolvedValue;
       return await source.get(name);
     }, undefined);
 


### PR DESCRIPTION
When running the reduce across the list of sources, the second
iteration would check the resolution of the previous source
invocation. This would not wait for resolution of the Promise,
and as such always resulted in a positive result, which, when
resolved downstream, could in fact be undefined, as the source
did not contain the intended configuration